### PR TITLE
Fixed DPI issue by setting anchor points

### DIFF
--- a/BandagedBD/Controls/DiscordLocator.Designer.cs
+++ b/BandagedBD/Controls/DiscordLocator.Designer.cs
@@ -40,11 +40,10 @@
             // 
             // titleLabel
             // 
-            this.titleLabel.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.titleLabel.AutoSize = true;
             this.titleLabel.BackColor = System.Drawing.Color.Transparent;
             this.titleLabel.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.titleLabel.Location = new System.Drawing.Point(6, 9);
+            this.titleLabel.Location = new System.Drawing.Point(7, 10);
             this.titleLabel.Name = "titleLabel";
             this.titleLabel.Size = new System.Drawing.Size(533, 13);
             this.titleLabel.TabIndex = 37;
@@ -53,15 +52,15 @@
             // 
             // browsePTB
             // 
-            this.browsePTB.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.browsePTB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.browsePTB.BackColor = global::BandagedBD.Properties.Settings.Default.Accent;
             this.browsePTB.Cursor = System.Windows.Forms.Cursors.Hand;
             this.browsePTB.FlatAppearance.BorderSize = 0;
             this.browsePTB.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.browsePTB.ForeColor = System.Drawing.Color.White;
-            this.browsePTB.Location = new System.Drawing.Point(573, 120);
+            this.browsePTB.Location = new System.Drawing.Point(657, 138);
             this.browsePTB.Name = "browsePTB";
-            this.browsePTB.Size = new System.Drawing.Size(75, 23);
+            this.browsePTB.Size = new System.Drawing.Size(86, 26);
             this.browsePTB.TabIndex = 36;
             this.browsePTB.Text = "Browse";
             this.browsePTB.UseVisualStyleBackColor = false;
@@ -69,37 +68,39 @@
             // 
             // tbPTB
             // 
-            this.tbPTB.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.tbPTB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tbPTB.BackColor = global::BandagedBD.Properties.Settings.Default.SecondaryBackground;
             this.tbPTB.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.tbPTB.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.tbPTB.ForeColor = System.Drawing.Color.White;
-            this.tbPTB.Location = new System.Drawing.Point(169, 125);
+            this.tbPTB.Location = new System.Drawing.Point(194, 143);
             this.tbPTB.Name = "tbPTB";
             this.tbPTB.ReadOnly = true;
-            this.tbPTB.Size = new System.Drawing.Size(385, 13);
+            this.tbPTB.Size = new System.Drawing.Size(441, 15);
             this.tbPTB.TabIndex = 34;
             // 
             // panel3
             // 
-            this.panel3.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.panel3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel3.BackColor = global::BandagedBD.Properties.Settings.Default.SecondaryBackground;
-            this.panel3.Location = new System.Drawing.Point(156, 120);
+            this.panel3.Location = new System.Drawing.Point(179, 138);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(411, 23);
+            this.panel3.Size = new System.Drawing.Size(471, 26);
             this.panel3.TabIndex = 35;
             // 
             // browseCanary
             // 
-            this.browseCanary.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.browseCanary.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.browseCanary.BackColor = global::BandagedBD.Properties.Settings.Default.Accent;
             this.browseCanary.Cursor = System.Windows.Forms.Cursors.Hand;
             this.browseCanary.FlatAppearance.BorderSize = 0;
             this.browseCanary.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.browseCanary.ForeColor = System.Drawing.Color.White;
-            this.browseCanary.Location = new System.Drawing.Point(573, 78);
+            this.browseCanary.Location = new System.Drawing.Point(657, 89);
             this.browseCanary.Name = "browseCanary";
-            this.browseCanary.Size = new System.Drawing.Size(75, 23);
+            this.browseCanary.Size = new System.Drawing.Size(86, 26);
             this.browseCanary.TabIndex = 33;
             this.browseCanary.Text = "Browse";
             this.browseCanary.UseVisualStyleBackColor = false;
@@ -107,37 +108,39 @@
             // 
             // tbCanary
             // 
-            this.tbCanary.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.tbCanary.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tbCanary.BackColor = global::BandagedBD.Properties.Settings.Default.SecondaryBackground;
             this.tbCanary.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.tbCanary.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.tbCanary.ForeColor = System.Drawing.Color.White;
-            this.tbCanary.Location = new System.Drawing.Point(169, 83);
+            this.tbCanary.Location = new System.Drawing.Point(194, 95);
             this.tbCanary.Name = "tbCanary";
             this.tbCanary.ReadOnly = true;
-            this.tbCanary.Size = new System.Drawing.Size(385, 13);
+            this.tbCanary.Size = new System.Drawing.Size(441, 15);
             this.tbCanary.TabIndex = 31;
             // 
             // panel1
             // 
-            this.panel1.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel1.BackColor = global::BandagedBD.Properties.Settings.Default.SecondaryBackground;
-            this.panel1.Location = new System.Drawing.Point(156, 78);
+            this.panel1.Location = new System.Drawing.Point(179, 89);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(411, 23);
+            this.panel1.Size = new System.Drawing.Size(471, 26);
             this.panel1.TabIndex = 32;
             // 
             // browseStable
             // 
-            this.browseStable.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.browseStable.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.browseStable.BackColor = global::BandagedBD.Properties.Settings.Default.Accent;
             this.browseStable.Cursor = System.Windows.Forms.Cursors.Hand;
             this.browseStable.FlatAppearance.BorderSize = 0;
             this.browseStable.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.browseStable.ForeColor = System.Drawing.Color.White;
-            this.browseStable.Location = new System.Drawing.Point(573, 37);
+            this.browseStable.Location = new System.Drawing.Point(657, 42);
             this.browseStable.Name = "browseStable";
-            this.browseStable.Size = new System.Drawing.Size(75, 23);
+            this.browseStable.Size = new System.Drawing.Size(86, 26);
             this.browseStable.TabIndex = 30;
             this.browseStable.Text = "Browse";
             this.browseStable.UseVisualStyleBackColor = false;
@@ -145,35 +148,36 @@
             // 
             // tbStable
             // 
-            this.tbStable.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.tbStable.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tbStable.BackColor = global::BandagedBD.Properties.Settings.Default.SecondaryBackground;
             this.tbStable.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.tbStable.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.tbStable.ForeColor = System.Drawing.Color.White;
-            this.tbStable.Location = new System.Drawing.Point(169, 42);
+            this.tbStable.Location = new System.Drawing.Point(194, 48);
             this.tbStable.Name = "tbStable";
             this.tbStable.ReadOnly = true;
-            this.tbStable.Size = new System.Drawing.Size(385, 13);
+            this.tbStable.Size = new System.Drawing.Size(441, 15);
             this.tbStable.TabIndex = 28;
             // 
             // panel2
             // 
-            this.panel2.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.panel2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel2.BackColor = global::BandagedBD.Properties.Settings.Default.SecondaryBackground;
-            this.panel2.Location = new System.Drawing.Point(156, 37);
+            this.panel2.Location = new System.Drawing.Point(179, 42);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(411, 23);
+            this.panel2.Size = new System.Drawing.Size(471, 26);
             this.panel2.TabIndex = 29;
             // 
             // discordPTB
             // 
-            this.discordPTB.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.discordPTB.AutoSize = true;
             this.discordPTB.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
             this.discordPTB.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.discordPTB.Cursor = System.Windows.Forms.Cursors.Hand;
             this.discordPTB.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.discordPTB.Location = new System.Drawing.Point(9, 124);
+            this.discordPTB.Location = new System.Drawing.Point(10, 142);
             this.discordPTB.Name = "discordPTB";
             this.discordPTB.Size = new System.Drawing.Size(98, 17);
             this.discordPTB.TabIndex = 27;
@@ -183,13 +187,12 @@
             // 
             // discordCanary
             // 
-            this.discordCanary.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.discordCanary.AutoSize = true;
             this.discordCanary.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
             this.discordCanary.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.discordCanary.Cursor = System.Windows.Forms.Cursors.Hand;
             this.discordCanary.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.discordCanary.Location = new System.Drawing.Point(9, 82);
+            this.discordCanary.Location = new System.Drawing.Point(10, 94);
             this.discordCanary.Name = "discordCanary";
             this.discordCanary.Size = new System.Drawing.Size(110, 17);
             this.discordCanary.TabIndex = 26;
@@ -199,13 +202,12 @@
             // 
             // discordStable
             // 
-            this.discordStable.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.discordStable.AutoSize = true;
             this.discordStable.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
             this.discordStable.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.discordStable.Cursor = System.Windows.Forms.Cursors.Hand;
             this.discordStable.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.discordStable.Location = new System.Drawing.Point(9, 41);
+            this.discordStable.Location = new System.Drawing.Point(10, 47);
             this.discordStable.Name = "discordStable";
             this.discordStable.Size = new System.Drawing.Size(107, 17);
             this.discordStable.TabIndex = 25;
@@ -215,7 +217,7 @@
             // 
             // DiscordLocator
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(110F, 110F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.Transparent;
             this.Controls.Add(this.titleLabel);
@@ -232,7 +234,7 @@
             this.Controls.Add(this.discordCanary);
             this.Controls.Add(this.discordStable);
             this.Name = "DiscordLocator";
-            this.Size = new System.Drawing.Size(662, 161);
+            this.Size = new System.Drawing.Size(759, 184);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/BandagedBD/FormMain.Designer.cs
+++ b/BandagedBD/FormMain.Designer.cs
@@ -62,7 +62,7 @@ namespace BandagedBD {
             this.lblTitle.ForeColor = System.Drawing.Color.White;
             this.lblTitle.Location = new System.Drawing.Point(82, 37);
             this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(145, 16);
+            this.lblTitle.Size = new System.Drawing.Size(153, 18);
             this.lblTitle.TabIndex = 5;
             this.lblTitle.Text = "BandagedBD Setup";
             // 
@@ -86,9 +86,9 @@ namespace BandagedBD {
             this.linkLabel1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.linkLabel1.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.linkLabel1.LinkColor = global::BandagedBD.Properties.Settings.Default.Accent;
-            this.linkLabel1.Location = new System.Drawing.Point(132, 471);
+            this.linkLabel1.Location = new System.Drawing.Point(172, 471);
             this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(95, 13);
+            this.linkLabel1.Size = new System.Drawing.Size(120, 16);
             this.linkLabel1.TabIndex = 34;
             this.linkLabel1.TabStop = true;
             this.linkLabel1.Text = "Consider donating.";
@@ -103,12 +103,13 @@ namespace BandagedBD {
             this.label1.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
             this.label1.Location = new System.Drawing.Point(13, 471);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(120, 13);
+            this.label1.Size = new System.Drawing.Size(153, 16);
             this.label1.TabIndex = 33;
             this.label1.Text = "Enjoying BandagedBD?";
             // 
             // btnCancel
             // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.BackColor = global::BandagedBD.Properties.Settings.Default.Accent;
             this.btnCancel.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
@@ -125,6 +126,7 @@ namespace BandagedBD {
             // 
             // btnNext
             // 
+            this.btnNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnNext.BackColor = global::BandagedBD.Properties.Settings.Default.Accent;
             this.btnNext.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnNext.FlatAppearance.BorderSize = 0;
@@ -140,6 +142,7 @@ namespace BandagedBD {
             // 
             // btnBack
             // 
+            this.btnBack.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnBack.BackColor = global::BandagedBD.Properties.Settings.Default.Accent;
             this.btnBack.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnBack.FlatAppearance.BorderSize = 0;
@@ -166,6 +169,7 @@ namespace BandagedBD {
             this.Controls.Add(this.lblTitle);
             this.Controls.Add(this.logo);
             this.Controls.Add(this.panelDock);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
             this.Name = "FormMain";

--- a/BandagedBD/Panels/InstallConfigPanel.Designer.cs
+++ b/BandagedBD/Panels/InstallConfigPanel.Designer.cs
@@ -35,7 +35,7 @@
             // 
             // cbShouldRestart
             // 
-            this.cbShouldRestart.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.cbShouldRestart.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.cbShouldRestart.AutoSize = true;
             this.cbShouldRestart.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
             this.cbShouldRestart.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
@@ -44,7 +44,7 @@
             this.cbShouldRestart.Cursor = System.Windows.Forms.Cursors.Hand;
             this.cbShouldRestart.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
             this.cbShouldRestart.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.cbShouldRestart.Location = new System.Drawing.Point(9, 196);
+            this.cbShouldRestart.Location = new System.Drawing.Point(9, 212);
             this.cbShouldRestart.Name = "cbShouldRestart";
             this.cbShouldRestart.Size = new System.Drawing.Size(162, 17);
             this.cbShouldRestart.TabIndex = 5;
@@ -53,19 +53,19 @@
             // 
             // discordLocator
             // 
-            this.discordLocator.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.discordLocator.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.discordLocator.BackColor = System.Drawing.Color.Transparent;
             this.discordLocator.Location = new System.Drawing.Point(0, 3);
             this.discordLocator.Name = "discordLocator";
-            this.discordLocator.Size = new System.Drawing.Size(662, 161);
+            this.discordLocator.Size = new System.Drawing.Size(662, 176);
             this.discordLocator.TabIndex = 6;
             // 
             // label1
             // 
-            this.label1.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.label1.AutoSize = true;
             this.label1.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.label1.Location = new System.Drawing.Point(6, 170);
+            this.label1.Location = new System.Drawing.Point(6, 186);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(95, 13);
             this.label1.TabIndex = 8;
@@ -81,6 +81,7 @@
             this.Controls.Add(this.discordLocator);
             this.Name = "InstallConfigPanel";
             this.Size = new System.Drawing.Size(662, 284);
+            this.Load += new System.EventHandler(this.InstallConfigPanel_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/BandagedBD/Panels/InstallConfigPanel.cs
+++ b/BandagedBD/Panels/InstallConfigPanel.cs
@@ -37,5 +37,9 @@ namespace BandagedBD.Panels {
             if (discordLocator.stable || discordLocator.canary || discordLocator.ptb) Window.btnNext.ShowEnable("Install");
             else Window.btnNext.ShowDisable("Install");
         }
+
+        private void InstallConfigPanel_Load(object sender, EventArgs e) {
+
+        }
     }
 }

--- a/BandagedBD/Panels/RepairConfigPanel.Designer.cs
+++ b/BandagedBD/Panels/RepairConfigPanel.Designer.cs
@@ -46,7 +46,7 @@
             this.label2.AutoSize = true;
             this.label2.BackColor = System.Drawing.Color.Transparent;
             this.label2.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.label2.Location = new System.Drawing.Point(6, 197);
+            this.label2.Location = new System.Drawing.Point(6, 212);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(292, 13);
             this.label2.TabIndex = 25;
@@ -56,9 +56,11 @@
             // 
             this.cbBootLoop.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.cbBootLoop.AutoSize = true;
+            this.cbBootLoop.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.cbBootLoop.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.cbBootLoop.Cursor = System.Windows.Forms.Cursors.Hand;
             this.cbBootLoop.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.cbBootLoop.Location = new System.Drawing.Point(120, 223);
+            this.cbBootLoop.Location = new System.Drawing.Point(120, 238);
             this.cbBootLoop.Name = "cbBootLoop";
             this.cbBootLoop.Size = new System.Drawing.Size(121, 17);
             this.cbBootLoop.TabIndex = 26;
@@ -69,9 +71,11 @@
             // 
             this.cbInfinite.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.cbInfinite.AutoSize = true;
+            this.cbInfinite.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.cbInfinite.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.cbInfinite.Cursor = System.Windows.Forms.Cursors.Hand;
             this.cbInfinite.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.cbInfinite.Location = new System.Drawing.Point(120, 257);
+            this.cbInfinite.Location = new System.Drawing.Point(120, 272);
             this.cbInfinite.Name = "cbInfinite";
             this.cbInfinite.Size = new System.Drawing.Size(167, 17);
             this.cbInfinite.TabIndex = 27;
@@ -82,9 +86,11 @@
             // 
             this.cbError.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.cbError.AutoSize = true;
+            this.cbError.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.cbError.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.cbError.Cursor = System.Windows.Forms.Cursors.Hand;
             this.cbError.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.cbError.Location = new System.Drawing.Point(358, 257);
+            this.cbError.Location = new System.Drawing.Point(358, 272);
             this.cbError.Name = "cbError";
             this.cbError.Size = new System.Drawing.Size(176, 17);
             this.cbError.TabIndex = 28;
@@ -95,9 +101,11 @@
             // 
             this.cbUninjected.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.cbUninjected.AutoSize = true;
+            this.cbUninjected.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.cbUninjected.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.cbUninjected.Cursor = System.Windows.Forms.Cursors.Hand;
             this.cbUninjected.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.cbUninjected.Location = new System.Drawing.Point(358, 223);
+            this.cbUninjected.Location = new System.Drawing.Point(358, 238);
             this.cbUninjected.Name = "cbUninjected";
             this.cbUninjected.Size = new System.Drawing.Size(218, 17);
             this.cbUninjected.TabIndex = 29;
@@ -110,7 +118,7 @@
             this.discordLocator.BackColor = System.Drawing.Color.Transparent;
             this.discordLocator.Location = new System.Drawing.Point(0, 2);
             this.discordLocator.Name = "discordLocator";
-            this.discordLocator.Size = new System.Drawing.Size(662, 161);
+            this.discordLocator.Size = new System.Drawing.Size(662, 175);
             this.discordLocator.TabIndex = 30;
             // 
             // label1
@@ -119,9 +127,9 @@
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.label1.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.label1.Location = new System.Drawing.Point(179, 308);
+            this.label1.Location = new System.Drawing.Point(141, 307);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(144, 13);
+            this.label1.Size = new System.Drawing.Size(181, 16);
             this.label1.TabIndex = 31;
             this.label1.Text = "Can\'t find your problem here?";
             // 
@@ -134,9 +142,9 @@
             this.linkLabel1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.linkLabel1.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.linkLabel1.LinkColor = global::BandagedBD.Properties.Settings.Default.Accent;
-            this.linkLabel1.Location = new System.Drawing.Point(322, 308);
+            this.linkLabel1.Location = new System.Drawing.Point(328, 307);
             this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(114, 13);
+            this.linkLabel1.Size = new System.Drawing.Size(143, 16);
             this.linkLabel1.TabIndex = 32;
             this.linkLabel1.TabStop = true;
             this.linkLabel1.Text = "Try this troubleshooter.";
@@ -145,10 +153,10 @@
             // 
             // label3
             // 
-            this.label3.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.label3.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.label3.AutoSize = true;
             this.label3.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.label3.Location = new System.Drawing.Point(6, 169);
+            this.label3.Location = new System.Drawing.Point(6, 184);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(95, 13);
             this.label3.TabIndex = 34;
@@ -156,14 +164,16 @@
             // 
             // cbShouldRestart
             // 
-            this.cbShouldRestart.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.cbShouldRestart.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.cbShouldRestart.AutoSize = true;
+            this.cbShouldRestart.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.cbShouldRestart.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.cbShouldRestart.Checked = true;
             this.cbShouldRestart.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbShouldRestart.Cursor = System.Windows.Forms.Cursors.Hand;
             this.cbShouldRestart.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
             this.cbShouldRestart.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.cbShouldRestart.Location = new System.Drawing.Point(120, 168);
+            this.cbShouldRestart.Location = new System.Drawing.Point(120, 183);
             this.cbShouldRestart.Name = "cbShouldRestart";
             this.cbShouldRestart.Size = new System.Drawing.Size(162, 17);
             this.cbShouldRestart.TabIndex = 33;

--- a/BandagedBD/Panels/RepairConfigPanel.cs
+++ b/BandagedBD/Panels/RepairConfigPanel.cs
@@ -52,5 +52,6 @@ namespace BandagedBD.Panels {
         private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) {
             Utilities.OpenProcess("https://0x71.cc/bd/troubleshoot/");
         }
+
     }
 }

--- a/BandagedBD/Panels/UninstallConfigPanel.Designer.cs
+++ b/BandagedBD/Panels/UninstallConfigPanel.Designer.cs
@@ -36,12 +36,14 @@
             // 
             // userData
             // 
-            this.userData.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.userData.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.userData.AutoSize = true;
+            this.userData.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.userData.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.userData.Cursor = System.Windows.Forms.Cursors.Hand;
             this.userData.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
             this.userData.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.userData.Location = new System.Drawing.Point(9, 196);
+            this.userData.Location = new System.Drawing.Point(9, 209);
             this.userData.Name = "userData";
             this.userData.Size = new System.Drawing.Size(170, 17);
             this.userData.TabIndex = 5;
@@ -50,10 +52,10 @@
             // 
             // label1
             // 
-            this.label1.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.label1.AutoSize = true;
             this.label1.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.label1.Location = new System.Drawing.Point(6, 170);
+            this.label1.Location = new System.Drawing.Point(6, 183);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(95, 13);
             this.label1.TabIndex = 7;
@@ -61,14 +63,16 @@
             // 
             // cbShouldRestart
             // 
-            this.cbShouldRestart.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.cbShouldRestart.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.cbShouldRestart.AutoSize = true;
+            this.cbShouldRestart.BoxBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(60)))), ((int)(((byte)(60)))));
+            this.cbShouldRestart.BoxForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(62)))), ((int)(((byte)(130)))), ((int)(((byte)(229)))));
             this.cbShouldRestart.Checked = true;
             this.cbShouldRestart.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbShouldRestart.Cursor = System.Windows.Forms.Cursors.Hand;
             this.cbShouldRestart.FlatAppearance.CheckedBackColor = System.Drawing.Color.Transparent;
             this.cbShouldRestart.ForeColor = global::BandagedBD.Properties.Settings.Default.TextColor;
-            this.cbShouldRestart.Location = new System.Drawing.Point(9, 219);
+            this.cbShouldRestart.Location = new System.Drawing.Point(9, 232);
             this.cbShouldRestart.Name = "cbShouldRestart";
             this.cbShouldRestart.Size = new System.Drawing.Size(162, 17);
             this.cbShouldRestart.TabIndex = 34;
@@ -77,11 +81,11 @@
             // 
             // discordLocator
             // 
-            this.discordLocator.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.discordLocator.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.discordLocator.BackColor = System.Drawing.Color.Transparent;
             this.discordLocator.Location = new System.Drawing.Point(0, 3);
             this.discordLocator.Name = "discordLocator";
-            this.discordLocator.Size = new System.Drawing.Size(662, 161);
+            this.discordLocator.Size = new System.Drawing.Size(662, 177);
             this.discordLocator.TabIndex = 6;
             // 
             // UninstallConfigPanel

--- a/BandagedBD/Panels/UninstallConfigPanel.cs
+++ b/BandagedBD/Panels/UninstallConfigPanel.cs
@@ -43,5 +43,6 @@ namespace BandagedBD.Panels {
             if (discordLocator.stable || discordLocator.canary || discordLocator.ptb) Window.btnNext.ShowEnable("Uninstall");
             else Window.btnNext.ShowDisable("Uninstall");
         }
+
     }
 }


### PR DESCRIPTION
Modified the anchor settings for many of the controls to allow the screen to be resized without any issues.

Set the Form to be FixedDialog to stop the user form maximizing the window. The scaling can allow for the window to be resized but it has been disabled, if this is the intended function re-enable it by setting the Form -> Properties -> FormBorderStyle back to Sizable although this would decouple the panel size from the window and only the buttons in the bottom right would move, you would have to set the panel anchor sizing too.

Fixes for issues:

rauenzi/BBDInstaller#3
rauenzi/BBDInstaller#5

See image for example: 
Left window = Original.
Right window = Application with correct anchoring.

![image](https://user-images.githubusercontent.com/6545688/78572248-20554580-781f-11ea-8f91-42a48685f1c5.png)

![image](https://user-images.githubusercontent.com/6545688/78572748-bee1a680-781f-11ea-9834-c198fc3b38d1.png)
