### PR TITLE
Added silent install ability

### DIFF
--- a/BandagedBD/BandagedBD.csproj
+++ b/BandagedBD/BandagedBD.csproj
@@ -150,6 +150,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Silent\SilentOnlyUtilities.cs" />
     <Compile Include="Utilities.cs" />
     <EmbeddedResource Include="FormMain.resx">
       <DependentUpon>FormMain.cs</DependentUpon>

--- a/BandagedBD/Program.cs
+++ b/BandagedBD/Program.cs
@@ -1,5 +1,6 @@
 ﻿using BandagedBD.Silent;
 using System;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace BandagedBD {
@@ -9,44 +10,51 @@ namespace BandagedBD {
         /// </summary>
         [STAThread]
 
+        [DllImport("kernel32.dll")]
+        static extern bool AttachConsole(int dwProcessId);
+        private const int ATTACH_PARENT_PROCESS = -1;
+
         static void Main(string[] args) {
             LaunchMode launchMode = LaunchMode.GUI;
 
             // check first argument to check if it is a silent install switch
-            switch (args[0].ToLower()) {
-                // Silent Install switches
-                case "-install":
-                case "-i":
-                    launchMode = LaunchMode.Install;
-                    break;
-                case "-repair":
-                case "-r":
-                    launchMode = LaunchMode.Repair;
-                    break;
-                case "-uninstall":
-                case "-u":
-                    launchMode = LaunchMode.Uninstall;
-                    break;
-                case "-help":
-                case "-h":
-                    launchMode = LaunchMode.None;
-                    Console.WriteLine("-install, -i   Install BBD\n" +
-                        "-uninstall, -u   Uninstall BBD\n" +
-                        "   Optional switches for uninstall\n" +
-                        "      -deleteuserdata   deletes all user settings of betterdiscord\n" +
-                        "-repair, -r   Repair BBD\n" +
-                        "   Optional switches for repair, for the following issues\n" +
-                        "      -repairupdateloop   Discord update loop\n" +
-                        "      -repairnotlaunching   BandagedBD not launching with Discord\n" +
-                        "      -repairloadingindefinitely   BandagedBD loading indefinitely\n" +
-                        "      -repairjavascripterror   Fatal JavaScript error on launch\n" +
-                        "\nall require using one or more of the following\n" +
-                        "   -stable [path], -canary [path], -ptb [path]\n" +
-                        "\n-norestart   By default discord will be restarted, this disables restarting of processes" +
-                        "");
-                    break;
-                default:
-                    break;
+            if (args.Length > 0) {
+                switch (args[0].ToLower()) {
+                    // Silent Install switches
+                    case "-install":
+                    case "-i":
+                        launchMode = LaunchMode.Install;
+                        break;
+                    case "-repair":
+                    case "-r":
+                        launchMode = LaunchMode.Repair;
+                        break;
+                    case "-uninstall":
+                    case "-u":
+                        launchMode = LaunchMode.Uninstall;
+                        break;
+                    case "-help":
+                    case "-h":
+                        launchMode = LaunchMode.None;
+                        AttachConsole(ATTACH_PARENT_PROCESS);
+                        Console.WriteLine("-install, -i   Install BBD\n" +
+                            "-uninstall, -u   Uninstall BBD\n" +
+                            "   Optional switches for uninstall\n" +
+                            "      -deleteuserdata   deletes all user settings of betterdiscord\n" +
+                            "-repair, -r   Repair BBD\n" +
+                            "   Optional switches for repair, for the following issues\n" +
+                            "      -repairupdateloop   Discord update loop\n" +
+                            "      -repairnotlaunching   BandagedBD not launching with Discord\n" +
+                            "      -repairloadingindefinitely   BandagedBD loading indefinitely\n" +
+                            "      -repairjavascripterror   Fatal JavaScript error on launch\n" +
+                            "\nall require using one or more of the following\n" +
+                            "   -stable [path], -canary [path], -ptb [path]\n" +
+                            "\n-norestart   By default discord will be restarted, this disables restarting of processes" +
+                            "");
+                        break;
+                    default:
+                        break;
+                }
             }
 
             switch (launchMode) {
@@ -58,6 +66,7 @@ namespace BandagedBD {
                 case LaunchMode.None:
                     break;
                 default:
+                    AttachConsole(ATTACH_PARENT_PROCESS);
                     new SilentOnlyUtilities(launchMode, args);
                     break;
             }

--- a/BandagedBD/Program.cs
+++ b/BandagedBD/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BandagedBD.Silent;
+using System;
 using System.Windows.Forms;
 
 namespace BandagedBD {
@@ -7,10 +8,59 @@ namespace BandagedBD {
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main() {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new FormMain());
-        }
+
+        static void Main(string[] args) {
+            LaunchMode launchMode = LaunchMode.GUI;
+
+            // check first argument to check if it is a silent install switch
+            switch (args[0].ToLower()) {
+                // Silent Install switches
+                case "-install":
+                case "-i":
+                    launchMode = LaunchMode.Install;
+                    break;
+                case "-repair":
+                case "-r":
+                    launchMode = LaunchMode.Repair;
+                    break;
+                case "-uninstall":
+                case "-u":
+                    launchMode = LaunchMode.Uninstall;
+                    break;
+                case "-help":
+                case "-h":
+                    launchMode = LaunchMode.None;
+                    Console.WriteLine("-install, -i   Install BBD\n" +
+                        "-uninstall, -u   Uninstall BBD\n" +
+                        "   Optional switches for uninstall\n" +
+                        "      -deleteuserdata   deletes all user settings of betterdiscord\n" +
+                        "-repair, -r   Repair BBD\n" +
+                        "   Optional switches for repair, for the following issues\n" +
+                        "      -repairupdateloop   Discord update loop\n" +
+                        "      -repairnotlaunching   BandagedBD not launching with Discord\n" +
+                        "      -repairloadingindefinitely   BandagedBD loading indefinitely\n" +
+                        "      -repairjavascripterror   Fatal JavaScript error on launch\n" +
+                        "\nall require using one or more of the following\n" +
+                        "   -stable [path], -canary [path], -ptb [path]\n" +
+                        "\n-norestart   By default discord will be restarted, this disables restarting of processes" +
+                        "");
+                    break;
+                default:
+                    break;
+            }
+
+            switch (launchMode) {
+                case LaunchMode.GUI:
+                    Application.EnableVisualStyles();
+                    Application.SetCompatibleTextRenderingDefault(false);
+                    Application.Run(new FormMain());
+                    break;
+                case LaunchMode.None:
+                    break;
+                default:
+                    new SilentOnlyUtilities(launchMode, args);
+                    break;
+            }
+        } 
     }
 }

--- a/BandagedBD/Silent/SilentOnlyUtilities.cs
+++ b/BandagedBD/Silent/SilentOnlyUtilities.cs
@@ -1,0 +1,308 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+
+namespace BandagedBD.Silent {
+    class SilentOnlyUtilities {
+        private bool useStable;
+        private bool useCanary;
+        private bool usePTB;
+
+        // Additional Options
+        private bool shouldRestart = true;
+
+        // Repair Options
+        public bool shouldDeleteRoaming;
+        public bool shouldDeleteLocal;
+        public bool shouldDeleteStorage;
+        public bool shouldReinstall;
+
+        // Uninstall Options
+        public bool shouldDeleteUserData;
+
+        // General
+        private string repo = "rauenzi";
+        private string branch = "injector";
+
+        private int iteration = 0;
+
+        private string[] processNames;
+        private string[] paths;
+        private string[] roamings;
+
+        private int progressChunk;
+
+        public string[] pathsToDelete {
+            get {
+                List<string> paths = new List<string>(Utilities.GetLocalPaths(useStable, useCanary, usePTB, "resources\\app"));
+                if (shouldDeleteUserData) paths.Add($"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\BetterDiscord");
+                return paths.ToArray();
+            }
+        }
+
+        public SilentOnlyUtilities(LaunchMode launchMode, string[] args) {
+            processArgs(args);
+
+            if (useStable || useCanary || usePTB) {
+                paths = Utilities.GetLocalPaths(useStable, useCanary, usePTB);
+                processNames = Utilities.GetExecutables(useStable, useCanary, usePTB);
+                roamings = Utilities.GetRoamingPaths(useStable, useCanary, usePTB);
+
+                if (paths.Length > 0) progressChunk = 100 / paths.Length;
+
+                switch (launchMode) {
+                    case LaunchMode.Install:
+                        Install();
+                        break;
+                    case LaunchMode.Repair:
+                        Repair();
+                        break;
+                    case LaunchMode.Uninstall:
+                        Uninstall();
+                        break;
+                }
+            } else {
+                Console.WriteLine("No branch specified, please use -stable, -canary or -ptb");
+            }
+        }
+
+        private void setProgress(int baseAmount) {
+            Console.WriteLine(((baseAmount * progressChunk) / 100) + (progressChunk * iteration) + "% of 100% complete");
+        }
+
+        private void processArgs(string[] args) {
+            for (int i = 0; i < args.Length; i++) {
+                switch (args[i].ToLower()) {
+                    // Path switches
+                    // If Path switch is found then next argument should be the path
+                    case "-stablepath":
+                    case "-stable":
+                        useStable = true;
+                        Utilities.CurrentStablePath = args[i + 1];
+                        i++;
+                        break;
+                    case "-canarypath":
+                    case "-canary":
+                        useCanary = true;
+                        Utilities.CurrentCanaryPath = args[i + 1];
+                        i++;
+                        break;
+                    case "-ptbpath":
+                    case "-ptb":
+                        usePTB = true;
+                        Utilities.CurrentPtbPath = args[i + 1];
+                        i++;
+                        break;
+
+                    // Additional Options switches
+                    case "-norestart":
+                        shouldRestart = false;
+                        break;
+
+                    // Repair switches
+                    case "-repairupdateloop":
+                        shouldDeleteRoaming = true;
+                        shouldDeleteLocal = true;
+                        shouldReinstall = true;
+                        break;
+                    case "-repairnotlaunching":
+                        shouldReinstall = true;
+                        break;
+                    case "-repairloadingindefinitely":
+                        shouldDeleteStorage = true;
+                        break;
+                    case "-repairjavascripterror":
+                        shouldDeleteRoaming = true;
+                        break;
+                    case "-deleteuserdata":
+                        shouldDeleteUserData = true;
+                        break;
+                }
+            }
+        }
+
+        private void Install() {
+            InstallTask();
+        }
+
+        private void Repair() {
+            List<string> exes = new List<string>();
+            foreach (var process in processNames) exes.Add(Utilities.KillProcess(process, Append));
+            if (shouldDeleteRoaming) Utilities.DeleteFolders(Utilities.GetRoamingPaths(useStable, useCanary, usePTB), Append);
+            if (shouldDeleteLocal) Utilities.DeleteFolders(Utilities.GetLocalPaths(useStable, useCanary, usePTB), Append);
+            if (shouldDeleteStorage) Utilities.DeleteFiles(new string[] { $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\BetterDiscord\\bdstorage.json" }, Append);
+            if (shouldReinstall) {
+                Install();
+            } else {
+                foreach (var exe in exes) {
+                    if (exe != string.Empty && shouldRestart) Utilities.OpenProcess(exe);
+                }
+                Append("Repairs completed!");
+            }
+        }
+
+        private void Uninstall() {
+            List<string> exes = new List<string>();
+            foreach (var process in processNames) exes.Add(Utilities.KillProcess(process, Append));
+            string[] deletePaths = pathsToDelete;
+            int chunk = 80 / deletePaths.Length;
+            int i = 0;
+            int newValue = 20;
+            Utilities.DeleteFolders(deletePaths, (message) => {
+                Append(message);
+                newValue = (chunk * i + chunk) + 20;
+                i++;
+            });
+            foreach (var exe in exes) {
+                if (exe != string.Empty && shouldRestart) Utilities.OpenProcess(exe);
+            }
+            Append("Uninstalling Complete!");
+        }
+
+        private int InstallTask() {
+            for (int i = 0; i < paths.Length; i++) {
+                iteration = i;
+                Append($"Starting installation for {processNames[i]}");
+                Append($"Killing {processNames[i]} Processes");
+                string currentExecutable = Utilities.KillProcess(processNames[i], Append);
+
+                if (DownloadBd(paths[i]) != 1) {
+                    setProgress(0);
+                    Append("Download seems to have failed, will try once more.");
+                    if (DownloadBd(paths[i]) != 1) return 0;
+                }
+
+                setProgress(75);
+                if (Verify(paths[i]) != 1) return 0;
+                setProgress(90);
+                if (shouldRestart && currentExecutable != string.Empty) {
+                    Append($"Restarting {processNames[i]}");
+                    Utilities.OpenProcess(currentExecutable);
+                }
+                setProgress(100);
+                Append($"Finished installing BandagedBD for {processNames[i]}!");
+                Append("---------------------------------------------------------------------------------");
+            }
+            return 1;
+        }
+
+        private int DownloadBd(string installationPath) {
+            var channel = $"https://github.com/{repo}/BetterDiscordApp/archive/{branch}.zip";
+            var dest = $"{installationPath}\\resources\\BetterDiscord.zip";
+
+            Append("Downloading BandagedBD package");
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Ssl3;
+
+
+            using (var wc = new TimedWebClient()) {
+                wc.DownloadProgressChanged += (sender, args) => {
+                    setProgress(args.ProgressPercentage / 2);
+                };
+
+                Append($"Using channel: {channel}");
+                Append($"Downloading to: {dest}");
+
+                try {
+                    wc.DownloadFile(channel, dest);
+                } catch (WebException e) {
+                    Append("Download error: " + e.Message);
+                    return 0;
+                }
+
+            }
+
+            Append("Finished downloading BandagedBD package");
+
+            return ExtractBd(dest, $"{installationPath}\\resources");
+        }
+
+        private int ExtractBd(string path, string dest) {
+
+            if (Directory.Exists($"{dest}\\app")) {
+                Append("Deleting old BetterDiscord");
+                Directory.Delete($"{dest}\\app", true);
+            }
+
+            if (Directory.Exists($"{dest}\\BetterDiscordApp-{branch}")) {
+                Append($"Deleting old BetterDiscordApp-{branch}");
+                Directory.Delete($"{dest}\\BetterDiscordApp-{branch}", true);
+            }
+
+            Append("Extracting BandagedBD package");
+
+            if (!File.Exists(path)) {
+                Append($"BandagedBD package does not exist in: {path}. Cannot continue.");
+                return 0;
+            }
+
+            var zar = ZipFile.OpenRead(path);
+
+            if (!Directory.Exists(dest)) {
+                Directory.CreateDirectory(dest);
+            }
+
+            zar.ExtractToDirectory(dest);
+            zar.Dispose();
+            if (!Directory.Exists($"{dest}\\BetterDiscordApp-{branch}")) {
+                Append($"BandagedBD package does not exist in: {dest}\\BetterDiscordApp-{branch}. Cannot continue.");
+                return 0;
+            }
+
+            Append("Renaming package dir");
+
+            Directory.Move($"{dest}\\BetterDiscordApp-{branch}", $"{dest}\\app");
+
+            if (File.Exists(path)) {
+                Append($"Deleting temp file {path}");
+                File.Delete(path);
+            }
+
+            return 1;
+        }
+
+        private int Verify(string installationPath) {
+
+            Append("Verifying installation");
+            Append("Checking for old style injection");
+            foreach (var roaming in roamings) {
+                var core = $"{roaming}\\modules\\discord_desktop_core\\core";
+                Append($"Checking for old injection {roaming}");
+                if (!Directory.Exists(core)) continue;
+                Append($"Deleting old injection {roaming}");
+                try {
+                    Directory.Delete(roaming, true);
+                } catch {
+                    Append($"Please delete this folder: {roaming}");
+                }
+            }
+
+            var appFolder = $"{installationPath}\\resources\\app";
+            if (!Directory.Exists(appFolder)) {
+                Append($"{appFolder} does not exist! Verification failed!");
+                return 0;
+            }
+
+            var injectorFiles = new[] { "index.js", "package.json", "betterdiscord\\index.js", "betterdiscord\\preload.js", "betterdiscord\\config.json", "betterdiscord\\logger.js" };
+
+            foreach (var bdFile in injectorFiles) {
+                if (File.Exists($"{appFolder}\\{bdFile}")) {
+                    Append($"Verifying {appFolder}\\{bdFile}");
+                    continue;
+                }
+                Append($"{appFolder}\\{bdFile} does not exist! Verification failed!");
+                return 0;
+            }
+
+            Append("Verification successful");
+
+            return 1;
+        }
+
+        private void Append(string text) {
+            Console.WriteLine(text);
+        }
+    }
+}

--- a/BandagedBD/Utilities.cs
+++ b/BandagedBD/Utilities.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 namespace BandagedBD {
 
     public enum Discord { Stable, Canary, PTB };
+    public enum LaunchMode { GUI, Install, Repair, Uninstall, None };
 
     public class Utilities {
         public static readonly Regex _matcher = new Regex(@"[0-9]+\.[0-9]+\.[0-9]+");

--- a/README.md
+++ b/README.md
@@ -59,3 +59,21 @@ The native checkbox leaves a lot to be desired in terms of extensibility and cus
 ### FlatProgressBar
 
 Similar to the checkbox the native progressbar has little to no customization options. This paints a flat checkbox using the an offscreen image as adapted from this [StackOverflow answer](https://stackoverflow.com/a/7490884).
+
+### Silent Setup
+
+-install -i   Install BBD  
+-uninstall -u   Uninstall BBD  
+   Optional switches for uninstall  
+      -deleteuserdata   deletes all user settings of betterdiscord  
+      -repair -r   Repair BBD  
+   Optional switches for repair, for the following issues  
+      -repairupdateloop   Discord update loop  
+      -repairnotlaunching   BandagedBD not launching with Discord  
+      -repairloadingindefinitely   BandagedBD loading indefinitely  
+      -repairjavascripterror   Fatal JavaScript error on launch  
+  
+all require using one or more of the following  
+   -stable [path], -canary [path], -ptb [path]  
+  
+-norestart   By default discord will be restarted, this disables restarting of processes  


### PR DESCRIPTION
Made a copy of the code inside the install\repair and uninstall panels into SilentUtilitiesOnly as not to change too much base code and made those callable by using command line arguments.

Readme now contains information on how to use the silent setups and when the correct switch is used the program will not show a window and instead will just write to console.

As it stands the user must specify the path, eg `BandagedBD.exe -install -ptb "C:\CustomDiscord\DiscordPTB\app-0.0.54"` but later may change this so that `app-0.0.54` is not needed.